### PR TITLE
Fix checking if ModemManager is enabled

### DIFF
--- a/supervised-installer.sh
+++ b/supervised-installer.sh
@@ -28,7 +28,7 @@ command -v apparmor_parser > /dev/null 2>&1 || warn "No AppArmor support on host
 
 
 # Check if Modem Manager is enabled
-if systemctl list-unit-files ModemManager.service | grep enabled; then
+if systemctl is-enabled ModemManager.service | grep enabled; then
     warn "ModemManager service is enabled. This might cause issue when using serial devices."
 fi
 


### PR DESCRIPTION
The current check fails at least with `systemd` 245 as there is a column called `Vendor Preset` which is `enabled` for this service despite the service being disabled.
As this check probably worked in the past I guess that the `Vendor Preset` column was added later.
I'm also not sure since when `systemctl is-enabled` exists, but according to the man page `list-unit-files` gets the enablement state from `is-enabled`.

```
# systemctl list-unit-files | awk 'NR==1 || /ModemM/'
UNIT FILE                                  STATE           VENDOR PRESET
ModemManager.service                       disabled        enabled
```

Grepping for `enabled` is still fine, as `systemctl is-enabled` returns this:
```
# systemctl is-enabled docker
enabled
# systemctl is-enabled ModemManager.service
disabled
```